### PR TITLE
Gui user agreement pop-up

### DIFF
--- a/src/gui/gui_app.py
+++ b/src/gui/gui_app.py
@@ -1,13 +1,56 @@
-from PyQt5.QtWidgets import QApplication, QLabel, QWidget, QVBoxLayout
+from PyQt5.QtWidgets import QApplication, QMainWindow, QWidget, QStackedWidget
 import sys
+from pathlib import Path
+import shutil
+import src.gui.gui_eula_mgr.gui_perms_prompt as perms_prompt
+import src.param.param as param
+
+class MainWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Team 10 Capstone")
+        self.setMinimumSize(400, 300)
+
+        self.stack = QStackedWidget()
+        self.setCentralWidget(self.stack)
+
+        self.main_content = QWidget()
+        self.stack.addWidget(self.main_content)
+
+        self.eula_prompt = None 
+
+    def show_eula_prompt(self, eula_folder, persisted_eula):
+        # Remove old EULA prompt if it exists
+        if self.eula_prompt is not None:
+            self.stack.removeWidget(self.eula_prompt)
+            self.eula_prompt.deleteLater()
+            self.eula_prompt = None
+
+        # Create EULA prompt, passing a callback to restore the main content
+        self.eula_prompt = perms_prompt.PermsPromptWindow(
+            persisted_eula,
+            on_accept=self.restore_main_content
+        )
+        self.stack.addWidget(self.eula_prompt)
+        self.stack.setCurrentWidget(self.eula_prompt)
+
+    def restore_main_content(self):
+        self.stack.setCurrentWidget(self.main_content)
+        if self.eula_prompt is not None:
+            self.stack.removeWidget(self.eula_prompt)
+            self.eula_prompt.deleteLater()
+            self.eula_prompt = None
 
 def run_gui():
     app = QApplication(sys.argv)
-    window = QWidget()
-    window.setWindowTitle("PyQt GUI App")
-    layout = QVBoxLayout()
-    label = QLabel("Hello from PyQt GUI!")
-    layout.addWidget(label)
-    window.setLayout(layout)
+    window = MainWindow()
+    eula_folder = Path(param.program_file_path) / "eula"
+    persisted_eula = eula_folder / f"eula_{param.eula_date}.done"
+    if not persisted_eula.is_file():
+        if eula_folder.is_dir():
+            shutil.rmtree(eula_folder)
+        window.show_eula_prompt(eula_folder, persisted_eula)
+    #Other Content Loading ->
+    
     window.show()
     sys.exit(app.exec_())

--- a/src/gui/gui_eula_mgr/EULA.txt
+++ b/src/gui/gui_eula_mgr/EULA.txt
@@ -1,0 +1,15 @@
+END USER LICENSE AGREEMENT (EULA)
+
+By using this software ("the Program"), you acknowledge and agree to the following terms:
+
+1. **Access to Files**  
+   You grant the Program permission to access files stored on your computer as necessary for its operation.
+
+2. **User Consent for Data Transfer**  
+   The Program will not transmit, upload, or otherwise transfer any data from your computer to external servers or third parties without first seeking and obtaining your explicit consent.
+
+3. **Privacy and Security**  
+   The Program is designed to respect your privacy. All file access and data handling will be performed in accordance with your instructions and preferences.
+
+4. **Acceptance**  
+   By clicking "Yes", you indicate your acceptance of this agreement.

--- a/src/gui/gui_eula_mgr/gui_perms_prompt.py
+++ b/src/gui/gui_eula_mgr/gui_perms_prompt.py
@@ -1,0 +1,48 @@
+from PyQt5.QtWidgets import QApplication, QLabel, QWidget, QVBoxLayout, QPushButton, QTextEdit
+import sys
+from pathlib import Path
+import shutil
+import os
+
+class PermsPromptWindow(QWidget):
+    def __init__(self, eula_accept: Path, on_accept=None):
+        super().__init__()
+        self.eula_accept = eula_accept
+        self.on_accept = on_accept
+        
+        self.layout = QVBoxLayout()
+        self.setLayout(self.layout)
+
+        # Load EULA.txt
+        eula_path = Path(os.path.dirname(__file__)) / "EULA.txt"
+        if eula_path.exists():
+            with open(eula_path, "r", encoding="utf-8") as f:
+                eula_text = f.read()
+        else:
+            eula_text = "EULA file not found."
+
+        self.eula_display = QTextEdit()
+        self.eula_display.setReadOnly(True)
+        self.eula_display.setPlainText(eula_text)
+        self.layout.addWidget(self.eula_display)
+
+        self.label = QLabel("Do you accept the End User License Agreement?")
+        self.layout.addWidget(self.label)
+
+        self.yes_button = QPushButton("Yes")
+        self.no_button = QPushButton("No")
+        self.layout.addWidget(self.yes_button)
+        self.layout.addWidget(self.no_button)
+
+        self.yes_button.clicked.connect(self.handleYes)
+        self.no_button.clicked.connect(self.handleNo)
+
+    def handleYes(self):
+        self.label.setText("Thank you for accepting the EULA!")
+        self.eula_accept.parent.mkdir(parents=True, exist_ok=True)
+        self.eula_accept.touch(exist_ok=True)
+        if self.on_accept:
+            self.on_accept()
+
+    def handleNo(self):
+        sys.exit(0)

--- a/src/param/param.py
+++ b/src/param/param.py
@@ -6,6 +6,7 @@ import platform
 # For Builds and Versioning
 project_name = "Capstone Project Team 10"
 project_version = "1.0.0"
+eula_date = "January 1st 2026"
 program_file_path: str = ""
 log_max_count: int = 10
 log_file_naming_regex: str = r"(\d+)\.log$"


### PR DESCRIPTION

## 📝 Description

This pull request introduces a user-facing End User License Agreement (EULA) acceptance workflow to the GUI application. The main window logic is refactored to support showing a permissions prompt, and a new EULA prompt window is added. The EULA text is now included in the repository, and EULA acceptance is persisted to disk to ensure users accept the agreement before using the app.

**EULA Acceptance Workflow Integration:**

* Added a new `MainWindow` class in `gui_app.py` that manages the main content and a stacked widget for showing the EULA prompt, and refactored the application startup to display the EULA prompt if the user has not yet accepted the agreement.
* Implemented the `PermsPromptWindow` class in `gui_perms_prompt.py`, which displays the EULA text, asks for user consent, and persists acceptance to a file. If the user declines, the application exits.
* Added the EULA text as `EULA.txt` in the repository, which is loaded and displayed to the user in the prompt.

**Parameter and Persistence Updates:**

* Added `eula_date` to `param.py` and updated logic in `gui_app.py` to use a versioned EULA acceptance file, ensuring users are prompted again if the EULA changes. [[1]](diffhunk://#diff-9a427886cc9ca0344a7cfb42150cc554523f66a10dc9e7197a904d2a6464d57eR9) [[2]](diffhunk://#diff-789258f37e997ff87d395de1410f9829995ef4beaf529b7128dec026abe311afL1-R54)
* 

**Closes:** #170

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [X] ✅ Test added/updated
- [X] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

- [X] Open the app and reject the prompt -> The app closes peacfully
- [X] Open the app and accept the prompt -> the app returns to the main page
- [X] Reopen the app after accepting the prompt -> no prompt is shown
- [X] Change the eula_date param and restart the app ->  prompt is shown
- [X] Resize the window and ensure that UI doesnt break -> it doesn't
---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [X] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [X] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>
<h2>Prompt</h2>
<img width="390" height="330" alt="image" src="https://github.com/user-attachments/assets/53cb1a4d-ee66-44c4-a906-9c87a52779c3" />
<h2>Folder for saving the users acceptance</h2>
<img width="482" height="204" alt="image" src="https://github.com/user-attachments/assets/e8971e6c-a4bb-4c5c-a09c-ce3eb751c6a2" />

</details>
