### PR TITLE
Fixed fas_pdf.py halting scan on error.

### DIFF
--- a/src/fas/fas_extra_data.py
+++ b/src/fas/fas_extra_data.py
@@ -73,11 +73,7 @@ def get_file_extra_data(file_path: str, file_type: str) -> Optional[Any]:
             _clean_summary(metadata)
             metadata["key_skills"] = _extract_text_skills(metadata)
 
-        # Returns None if metadata is empty
-        if metadata == {}:
-            return None
-        else:
-            return metadata
+        return metadata
 
     except ModuleNotFoundError:
         print(f"No handler found for file type: {file_type}")

--- a/src/fas/fas_pdf.py
+++ b/src/fas/fas_pdf.py
@@ -113,9 +113,7 @@ def extract_pdf_data(path: str) -> Dict[str, Any]:
 
         return metadata
 
-    except FileNotFoundError:
-        print(f"FAS_PDF: File could not be found at {path}")
-        return {}
+    except FileNotFoundError as e:
+        return {"error": str(e)}
     except Exception as e:
-        print(f"FAS_PDF: Error analyzing file: {str(e)} at {path}")
-        return {}
+        return {"error": str(e)}

--- a/tests/test_fas_pdf.py
+++ b/tests/test_fas_pdf.py
@@ -22,11 +22,13 @@ class TestPDF:
         return pdfr.extract_pdf_data(TESTPATH4)
     
     def test_file_not_found(self):
-        assert pdfr.extract_pdf_data(r"C:\badpath.pdf") == {}
+        metadata = pdfr.extract_pdf_data(r"C:\badpath.pdf")
+        assert metadata["error"] != None
     
     def test_invalid_file_type(self):
-        assert pdfr.extract_pdf_data(r"C:\badpath.pdf") == {}
-
+        metadata = pdfr.extract_pdf_data(r"C:\badpath.pdf")
+        assert metadata["error"] != None
+        
     def test_filepath(self, sample_pdf):
         assert sample_pdf["file_path"] == TESTPATH1
         assert isinstance(sample_pdf["file_path"], str)


### PR DESCRIPTION
Errors with pdf file analysis now print an error message and return an empty list. fas_extra_data handles this with a check if the returned metadata is empty.

<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

Changed pas_pdf.py to no longer raise errors when an exception is found. Instead it returns an empty list and prints our error messages to the terminal. The upstream changes have been made in fas_extra_data.py to manage empty list returns.

Closes: #168 

---

## 🔧 Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [X] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] 📚 Documentation added/updated
- [X] ✅ Test added/updated
- [X] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Modified tests to check updated error handling behaviour. 

- [X] Test file not found 
- [X] Test file is not a pdf

<img width="686" height="70" alt="image" src="https://github.com/user-attachments/assets/83952b10-19e1-427b-9622-14e59062855c" />

ensured all tests in fas_extra_data.py still pass.

<img width="2118" height="422" alt="image" src="https://github.com/user-attachments/assets/cd1a747b-0101-4e75-8784-487cdbe01252" />

---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [X] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---