### PR TITLE
Modified files retrieved by hash to increment scanned files.

### DIFF
--- a/src/fss/fss.py
+++ b/src/fss/fss.py
@@ -158,6 +158,7 @@ def search(search_params: FSS_Search):
 
             if file_result:
                 log.write(file_result)
+                num_of_files_scanned += 1
                 num_of_duplicates_found += 1
             else:
                 file_result: fas.FileAnalysis | None = fas.run_fas(file_path)

--- a/tests/test_fss.py
+++ b/tests/test_fss.py
@@ -144,6 +144,6 @@ class TestFSS:
         """Test that multiple file type filters work inside zip files."""
         result = fss.search(fss.FSS_Search(
             path_to_test_zip,
-            file_types={"txt", "md"}
+            file_types={"txt","md"}
         ))
         assert result == 2

--- a/tests/testdata/test_fss/testScanFile
+++ b/tests/testdata/test_fss/testScanFile
@@ -1977,4 +1977,3 @@ Adding a new line to force modification.
 Adding a new line to force modification.
 Adding a new line to force modification.
 Adding a new line to force modification.
-Adding a new line to force modification.


### PR DESCRIPTION

## 📝 Description

Previously scanned files that were saved in logs would not increment the scanned files from the fss.search() function. This caused differences in the return value depending on if the files existed in a log or not. 

Closes: #235 

---

## 🔧 Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [X] ✅ Test added/updated
- [X] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [X] Test fss with zip file
- [X] Test fss with zile file multiple extension filters

---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [X] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [X] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---