### PR TITLE
[B] Scan Page bug fix

### DIFF
--- a/src/gui/gui_scan_page.py
+++ b/src/gui/gui_scan_page.py
@@ -73,20 +73,41 @@ class ScanPage(QtWidgets.QWidget):
         self.layout.addWidget(self.filter_summary)
 
     def browse_files(self):
-        file_dialog = QtWidgets.QFileDialog(
-            self, "Select a directory or zip file to scan"
-        )
-        file_dialog.setFileMode(QtWidgets.QFileDialog.AnyFile)
-        file_dialog.setOption(QtWidgets.QFileDialog.ShowDirsOnly, False)
-        file_dialog.setNameFilter("Zip files (*.zip);;All files (*)")
-        selected_path = ""
-        if file_dialog.exec_():
-            selected_path = file_dialog.selectedFiles()[0]
+        # QFileDialog can't reliably "click-select" a directory when it's configured
+        # for file selection. Use the dedicated directory picker for folders.
+        chooser = QtWidgets.QMessageBox(self)
+        chooser.setWindowTitle("Select Input")
+        chooser.setText("What would you like to scan?")
+        folder_btn = chooser.addButton("Folder", QtWidgets.QMessageBox.ActionRole)
+        zip_btn = chooser.addButton("Zip file (.zip)", QtWidgets.QMessageBox.ActionRole)
+        chooser.addButton(QtWidgets.QMessageBox.Cancel)
+        chooser.exec_()
 
-        if selected_path:
-            self.selected_directory = selected_path
-            # Display on GUI
-            self.directory_label.setText(f"Directory: {selected_path}")
+        if chooser.clickedButton() is folder_btn:
+            selected_path = QtWidgets.QFileDialog.getExistingDirectory(
+                self,
+                "Select a directory to scan",
+                "",
+                QtWidgets.QFileDialog.ShowDirsOnly,
+            )
+            if not selected_path:
+                return
+
+        elif chooser.clickedButton() is zip_btn:
+            selected_path, _ = QtWidgets.QFileDialog.getOpenFileName(
+                self,
+                "Select a zip file to scan",
+                "",
+                "Zip files (*.zip)",
+            )
+            if not selected_path:
+                return
+
+        else:
+            return
+
+        self.selected_directory = selected_path
+        self.directory_label.setText(f"Selected: {self.selected_directory}")
 
     def open_filter_dialog(self):
         filter_dialog = FilterDialog(self)
@@ -97,7 +118,7 @@ class ScanPage(QtWidgets.QWidget):
     def start_scan(self):
         if not self.selected_directory:
             QtWidgets.QMessageBox.warning(
-                self, "No Directory", "Please select a directory first."
+                self, "No Input", "Please select a directory or .zip file first."
             )
             return
 


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

A small update to revamp the dialogue window to access either directories or .zip files (looking at you who did a rogue push)

---

## 🔧 Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Manually test the Scan Page - previously, it was not able to pinpoint the directory with the old dialogue window - now it separates itself from choosing a .zip file

---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code, and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works, and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> Changes made

<details>
<summary>Before</summary>

<img width="1812" height="816" alt="image" src="https://github.com/user-attachments/assets/eddb2368-2a11-4030-b502-5854d2fbd91d" />

</details>

<details>
<summary>After</summary>

<img width="441" height="281" alt="image" src="https://github.com/user-attachments/assets/f27dc282-bb51-45ac-8be7-1910df50a371" />

<img width="1231" height="732" alt="image" src="https://github.com/user-attachments/assets/c51f4f3d-5318-4f90-8e79-63ca4ab7facd" />


</details>