### PR TITLE
Custom User Created Projects

### DIFF
--- a/src/gui/gui_dashboard/gui_log_details_page.py
+++ b/src/gui/gui_dashboard/gui_log_details_page.py
@@ -67,11 +67,11 @@ class CreateProjectDialog(QDialog):
         form.setLabelAlignment(Qt.AlignRight)
 
         self.id_edit = QLineEdit()
-        self.id_edit.setPlaceholderText("e.g. my-project-2024")
+        self.id_edit.setPlaceholderText("Enter Project ID")
         self.id_edit.setStyleSheet("color: black; padding: 6px; border: 1px solid #ccc; border-radius: 4px;")
 
         self.desc_edit = QLineEdit()
-        self.desc_edit.setPlaceholderText("Optional short description")
+        self.desc_edit.setPlaceholderText("Optional description")
         self.desc_edit.setStyleSheet("color: black; padding: 6px; border: 1px solid #ccc; border-radius: 4px;")
 
         lbl_style = "color: black; font-size: 13px;"


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

> Please include a summary of the change and which issue is fixed.  
> Include relevant motivation and context.  
> List any dependencies that are required for this change.

This PR adds the ability for a user to create their own projects should the scan miss a project that they want to add. It gives the user the ability to add a custom title and initial description that will be reflected in the logs, as well as following the standard set by other project entries in the logs (file path is project id, no created date or modified date beyond what is set by the user, and no file hash).

This works in tandem with the project add and remove functionality previously added to let the user assign whatever files scanned that they want to the project.

A full walkthrough of the functionality can be found in the screenshots section.

**Closes:** #259 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Manual testing was completed to ensure the front end worked as expected as well as updates to the logs and correct resume and portfolio generation from the given project.

An example can be seen in the screenshot section.

---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [X] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [X] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->
Log details page with "New Project" button
<img width="1137" height="727" alt="Screenshot 2026-03-08 at 5 32 25 PM" src="https://github.com/user-attachments/assets/9c80c101-29f3-470f-bf3c-ed8ef791116b" />

Create new project dialouge box
<img width="1137" height="725" alt="Screenshot 2026-03-08 at 5 34 56 PM" src="https://github.com/user-attachments/assets/565ba888-d632-4b6e-96dc-5b8f273d8c42" />

Operation success pop-up
<img width="1138" height="726" alt="Screenshot 2026-03-08 at 5 35 33 PM" src="https://github.com/user-attachments/assets/1b88929c-40d9-439a-b5c1-5720be9da025" />

Now displayed in projects list
<img width="1141" height="728" alt="Screenshot 2026-03-08 at 5 35 55 PM" src="https://github.com/user-attachments/assets/627fc0fc-b58a-4ba0-aa40-dc7f7b8472e0" />

Starts empty
<img width="1141" height="731" alt="Screenshot 2026-03-08 at 5 36 26 PM" src="https://github.com/user-attachments/assets/24cf1c28-59a6-449d-b756-a2560762f45e" />

Select files to add
<img width="1138" height="729" alt="Screenshot 2026-03-08 at 5 36 51 PM" src="https://github.com/user-attachments/assets/d2d70032-6439-4bd8-a223-ca25e1e7367d" />

Files added
<img width="1140" height="726" alt="Screenshot 2026-03-08 at 5 37 09 PM" src="https://github.com/user-attachments/assets/757d4ac0-cb61-4b9d-b4b3-ec14e1a8201a" />

New ID reflected in log
<img width="483" height="79" alt="Screenshot 2026-03-08 at 5 37 53 PM" src="https://github.com/user-attachments/assets/a42a5ad2-560f-47d8-83c5-3e729a83b679" />

New Project reflected in log
<img width="596" height="20" alt="Screenshot 2026-03-08 at 5 38 17 PM" src="https://github.com/user-attachments/assets/a0e4e08b-dafb-4809-b3b4-2003513f0e9c" />

Upon loading the log in resume/portfolio editor it contains the skills from all newly associated files
<img width="1139" height="727" alt="Screenshot 2026-03-08 at 5 39 01 PM" src="https://github.com/user-attachments/assets/56216ceb-4a6e-4ff3-83eb-8291b52cae7c" />

Correct generated output
<img width="594" height="227" alt="Screenshot 2026-03-08 at 5 40 05 PM" src="https://github.com/user-attachments/assets/232ece64-bbae-4247-b2a5-6924ff1bd290" />

</details>
